### PR TITLE
Add ability to specify the form of the worklog information

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -12,3 +12,7 @@ is_bool <- function(x) {
 is_string <- function(x) {
   is_chr_nomiss(x) && (length(x) == 1L)
 }
+
+is_maybe_string <- function(x) {
+  is.character(x) && (length(x) == 1L)
+}

--- a/R/validate.R
+++ b/R/validate.R
@@ -8,3 +8,7 @@ is_bool <- function(x) {
     && (! is.na(x))
   )
 }
+
+is_string <- function(x) {
+  is_chr_nomiss(x) && (length(x) == 1L)
+}

--- a/R/worklogs.R
+++ b/R/worklogs.R
@@ -1061,6 +1061,9 @@ format_effort_tree <- function(effort_descr_df, padding, depth) {
   flatten_chr(combined_sections)
 }
 
+# TODO: check the following:
+# - at least 2 out of 3 of start_label, end_label, and end_format
+# - exactly the right corresponding formatting inputs
 wkls_config <- function(description_label,
                         start_label,
                         start_format,
@@ -1072,14 +1075,14 @@ wkls_config <- function(description_label,
                         timezone) {
   stopifnot(
     is_string(description_label),
-    is_string(start_label),
-    is_string(start_format),
-    is_string(end_label),
-    is_string(end_format),
-    is_string(duration_label),
-    is_string(duration_format),
-    is_string(tags_label),
-    is_string(timezone)
+    is_maybe_string(start_label),
+    is_maybe_string(start_format),
+    is_maybe_string(end_label),
+    is_maybe_string(end_format),
+    is_maybe_string(duration_label),
+    is_maybe_string(duration_format),
+    is_maybe_string(tags_label),
+    is_maybe_string(timezone)
   )
   config <- list(
     labels = list(

--- a/R/worklogs.R
+++ b/R/worklogs.R
@@ -1061,18 +1061,61 @@ format_effort_tree <- function(effort_descr_df, padding, depth) {
   flatten_chr(combined_sections)
 }
 
+setClass("config_labels",
+  slots = c(
+    description = "character",
+    start       = "character",
+    end         = "character",
+    duration    = "character",
+    tags        = "character"
+ ),
+ prototype = list(
+    description = NA_character_,
+    start       = NA_character_,
+    end         = NA_character_,
+    duration    = NA_character_,
+    tags        = NA_character_
+  )
+)
+
+setClass("config_formats",
+  slots = c(
+    start    = "character",
+    end      = "character",
+    duration = "character"
+ ),
+ prototype = list(
+    start    = NA_character_,
+    end      = NA_character_,
+    duration = NA_character_
+  )
+)
+
+setClass("worklogs_config",
+  slots = c(
+    labels   = "config_labels",
+    formats  = "config_formats",
+    timezone = "character"
+  ),
+  prototype = list(
+    labels  = new("config_labels"),
+    formats = new("config_formats"),
+    timezone = NA_character_
+  )
+)
+
 # TODO: check the following:
 # - at least 2 out of 3 of start_label, end_label, and end_format
 # - exactly the right corresponding formatting inputs
-wkls_config <- function(description_label,
-                        start_label,
-                        start_format,
-                        end_label,
-                        end_format
-                        duration_label,
-                        duration_format,
-                        tags_label,
-                        timezone) {
+worklogs_config <- function(description_label,
+                            start_label,
+                            start_format,
+                            end_label,
+                            end_format,
+                            duration_label,
+                            duration_format,
+                            tags_label,
+                            timezone) {
   stopifnot(
     is_string(description_label),
     is_maybe_string(start_label),
@@ -1084,20 +1127,19 @@ wkls_config <- function(description_label,
     is_maybe_string(tags_label),
     is_maybe_string(timezone)
   )
-  config <- list(
-    labels = list(
+  new("worklogs_config",
+    labels = new("config_labels",
       description = description_label,
       start       = start_label,
       end         = end_label,
       duration    = duration_label,
       tags        = tags_label
     ),
-    formats = list(
+    formats = new("config_formats",
       start    = start_format,
       end      = end_format,
       duration = duration_format
     ),
     timezone = timezone
   )
-  structure(.Data = config, class = "wkls_config")
 }

--- a/R/worklogs.R
+++ b/R/worklogs.R
@@ -1060,3 +1060,41 @@ format_effort_tree <- function(effort_descr_df, padding, depth) {
   combined_sections <- map2(top_levels, formatted_children, c)
   flatten_chr(combined_sections)
 }
+
+wkls_config <- function(description_label,
+                        start_label,
+                        start_format,
+                        end_label,
+                        end_format
+                        duration_label,
+                        duration_format,
+                        tags_label,
+                        timezone) {
+  stopifnot(
+    is_string(description_label),
+    is_string(start_label),
+    is_string(start_format),
+    is_string(end_label),
+    is_string(end_format),
+    is_string(duration_label),
+    is_string(duration_format),
+    is_string(tags_label),
+    is_string(timezone)
+  )
+  config <- list(
+    labels = list(
+      description = description_label,
+      start       = start_label,
+      end         = end_label,
+      duration    = duration_label,
+      tags        = tags_label
+    ),
+    formats = list(
+      start    = start_format,
+      end      = end_format,
+      duration = duration_format
+    ),
+    timezone = timezone
+  )
+  structure(.Data = config, class = "wkls_config")
+}

--- a/R/worklogs.R
+++ b/R/worklogs.R
@@ -1,3 +1,85 @@
+setClass("config_labels",
+  slots = c(
+    description = "character",
+    start       = "character",
+    end         = "character",
+    duration    = "character",
+    tags        = "character"
+ ),
+ prototype = list(
+    description = NA_character_,
+    start       = NA_character_,
+    end         = NA_character_,
+    duration    = NA_character_,
+    tags        = NA_character_
+  )
+)
+
+setClass("config_formats",
+  slots = c(
+    start    = "character",
+    end      = "character",
+    duration = "character"
+ ),
+ prototype = list(
+    start    = NA_character_,
+    end      = NA_character_,
+    duration = NA_character_
+  )
+)
+
+setClass("worklogs_config",
+  slots = c(
+    labels   = "config_labels",
+    formats  = "config_formats",
+    timezone = "character"
+  ),
+  prototype = list(
+    labels  = new("config_labels"),
+    formats = new("config_formats"),
+    timezone = NA_character_
+  )
+)
+
+# TODO: check the following:
+# - at least 2 out of 3 of start_label, end_label, and end_format
+# - exactly the right corresponding formatting inputs
+worklogs_config <- function(description_label,
+                            start_label,
+                            start_format,
+                            end_label,
+                            end_format,
+                            duration_label,
+                            duration_format,
+                            tags_label,
+                            timezone) {
+  stopifnot(
+    is_string(description_label),
+    is_maybe_string(start_label),
+    is_maybe_string(start_format),
+    is_maybe_string(end_label),
+    is_maybe_string(end_format),
+    is_maybe_string(duration_label),
+    is_maybe_string(duration_format),
+    is_maybe_string(tags_label),
+    is_maybe_string(timezone)
+  )
+  new("worklogs_config",
+    labels = new("config_labels",
+      description = description_label,
+      start       = start_label,
+      end         = end_label,
+      duration    = duration_label,
+      tags        = tags_label
+    ),
+    formats = new("config_formats",
+      start    = start_format,
+      end      = end_format,
+      duration = duration_format
+    ),
+    timezone = timezone
+  )
+}
 setClass("worklogs_node",
   slots     = c(children = "list", fold_status = "character"),
   prototype = list(
@@ -1059,87 +1141,4 @@ format_effort_tree <- function(effort_descr_df, padding, depth) {
   )
   combined_sections <- map2(top_levels, formatted_children, c)
   flatten_chr(combined_sections)
-}
-
-setClass("config_labels",
-  slots = c(
-    description = "character",
-    start       = "character",
-    end         = "character",
-    duration    = "character",
-    tags        = "character"
- ),
- prototype = list(
-    description = NA_character_,
-    start       = NA_character_,
-    end         = NA_character_,
-    duration    = NA_character_,
-    tags        = NA_character_
-  )
-)
-
-setClass("config_formats",
-  slots = c(
-    start    = "character",
-    end      = "character",
-    duration = "character"
- ),
- prototype = list(
-    start    = NA_character_,
-    end      = NA_character_,
-    duration = NA_character_
-  )
-)
-
-setClass("worklogs_config",
-  slots = c(
-    labels   = "config_labels",
-    formats  = "config_formats",
-    timezone = "character"
-  ),
-  prototype = list(
-    labels  = new("config_labels"),
-    formats = new("config_formats"),
-    timezone = NA_character_
-  )
-)
-
-# TODO: check the following:
-# - at least 2 out of 3 of start_label, end_label, and end_format
-# - exactly the right corresponding formatting inputs
-worklogs_config <- function(description_label,
-                            start_label,
-                            start_format,
-                            end_label,
-                            end_format,
-                            duration_label,
-                            duration_format,
-                            tags_label,
-                            timezone) {
-  stopifnot(
-    is_string(description_label),
-    is_maybe_string(start_label),
-    is_maybe_string(start_format),
-    is_maybe_string(end_label),
-    is_maybe_string(end_format),
-    is_maybe_string(duration_label),
-    is_maybe_string(duration_format),
-    is_maybe_string(tags_label),
-    is_maybe_string(timezone)
-  )
-  new("worklogs_config",
-    labels = new("config_labels",
-      description = description_label,
-      start       = start_label,
-      end         = end_label,
-      duration    = duration_label,
-      tags        = tags_label
-    ),
-    formats = new("config_formats",
-      start    = start_format,
-      end      = end_format,
-      duration = duration_format
-    ),
-    timezone = timezone
-  )
 }

--- a/R/worklogs.R
+++ b/R/worklogs.R
@@ -1,3 +1,5 @@
+# `worklogs` configuration classes ---------------------------------------------
+
 setClass("config_labels",
   slots = c(
     description = "character",
@@ -80,6 +82,10 @@ worklogs_config <- function(description_label,
     timezone = timezone
   )
 }
+
+
+# `worklog` class defintions ---------------------------------------------------
+
 setClass("worklogs_node",
   slots     = c(children = "list", fold_status = "character"),
   prototype = list(
@@ -171,6 +177,9 @@ setMethod("worklogs",
   signature  = "data.frame",
   definition = mk_worklogs_leafs
 )
+
+
+# `worklogs` `show` method -----------------------------------------------------
 
 setGeneric("count_descendents",
   def = function(wkls) standardGeneric("count_descendents")
@@ -286,6 +295,9 @@ setMethod("show",
   signature  = "worklogs",
   definition = print_worklogs
 )
+
+
+# Updating `worklog` graph elements --------------------------------------------
 
 setGeneric("update_child",
   def       = function(wkls, path, parents, f) standardGeneric("update_child"),
@@ -433,6 +445,9 @@ setMethod("fold_children",
   definition = fold_children_impl
 )
 
+
+# Extract `worklog` graph elements -------------------------------------------------------
+
 setGeneric("extract_worklogs_impl",
   def       = function(wkls, path, parents) standardGeneric("extract_worklogs_impl"),
   signature = "wkls"
@@ -545,7 +560,7 @@ as_tibble.worklogs_leaf <- function(x, ...) {
 }
 
 
-# effort -----------------------------------------------------------------------
+# Effort summary ---------------------------------------------------------------
 
 # TODO: create validObject for the various classes
 


### PR DESCRIPTION
Suppose we that have information like the following:

``` yaml
parse_delimited:
  col_labels:
    description: "task"
    start: "start"
    end: null
    duration: "duration"
    tags: "tags"
  col_formats:
    start: "%Y-%m-%d %H:%M"
    end: null
    delimiter2: ":"
    timezone: "US/Eastern"
```

We'd like to be able to understand how to read the worklog information in a given data frame based on such a data dictionary.


### How do we need to store this information?

- As part of the `worklogs` object
  - It's redundant information across the nodes. Store it anyway?
  - We could translate (normalize) the worklogs data frames directly, but we
    need to be able to return a data frame of the original form for a call to
    `as.data.frame`
  - We may want to flatten the data to a data frame for internal uses (e.g.
    creating figures). Do we want to produce a normalized version for this use?


### What data type do we want to store the data dictionary?

- It's internal to us so using an S4 class wouldn't affect the user
- It's simple and static so maybe plain lists would be sufficient 


### How does the user specify the information?

- In the same form as we expect it to be?
- As "nested" inputs to constructor functions? E.g. a constructor for
  `col_labels` as well as a constructor for `col_formats` and a constructor to
  create the overall object
- As "flat" arguments to a function
